### PR TITLE
fix for buckets with "."s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /.vagga
 /test.py
 __pycache__
-
+*.egg-info/
 /dist
 /MANIFEST

--- a/aios3/__init__.py
+++ b/aios3/__init__.py
@@ -1,1 +1,1 @@
-from .bucket import Bucket
+from .bucket import Bucket, ObjectChunk

--- a/aios3/bucket.py
+++ b/aios3/bucket.py
@@ -323,6 +323,7 @@ class Bucket(object):
         if port != 80:
             self._host = self._host + ':' + str(port)
         self._signature = signature
+        self._session = aiohttp.ClientSession(connector=connector)
 
     @asyncio.coroutine
     def exists(self, prefix=''):
@@ -491,11 +492,10 @@ class Bucket(object):
         _SIGNATURES[self._signature](req, **self._aws_sign_data)
         if isinstance(req.payload, bytes):
             req.headers['CONTENT-LENGTH'] = str(len(req.payload))
-        return (yield from aiohttp.request(req.verb, req.url,
+        return (yield from self._session.request(req.verb, req.url,
             chunked='CONTENT-LENGTH' not in req.headers,
             headers=req.headers,
-            data=req.payload,
-            connector=self._connector))
+            data=req.payload))
 
     @asyncio.coroutine
     def upload_multipart(self, key,

--- a/aios3/bucket.py
+++ b/aios3/bucket.py
@@ -360,6 +360,9 @@ class Bucket(object):
         self._signature = signature
         self._session = aiohttp.ClientSession(connector=connector)
 
+    def __del__(self):
+        self._session.close()  # why is this not implicit?
+
     def _update_creds(self):
         if not self._cred_resolver: return
 

--- a/aios3/bucket.py
+++ b/aios3/bucket.py
@@ -58,7 +58,7 @@ class Request(object):
         self.verb = verb
         self.resource = amz_uriencode_slash(resource)
         self.params = query
-        self.query_string = '&'.join(k + '=' + v if v else k
+        self.query_string = '&'.join(k + '=' + v if v is not None else k
             for k, v in sorted((amz_uriencode(k), amz_uriencode(v) if v is not None else None)
                                for k, v in query.items()))
         self.headers = headers

--- a/aios3/bucket.py
+++ b/aios3/bucket.py
@@ -442,7 +442,7 @@ class Bucket(object):
             except:
                 # yes, we get multiple types of exceptions
                 retries += 1
-                self._logger.exception('Retrying {}/{} on s3 request: {}'.format(retries, self._num_retries, url))
+                self._logger.warning('Retrying {}/{} on s3 request: {}'.format(retries, self._num_retries, url))
                 if retries == self._num_retries:
                     raise
 

--- a/aios3/bucket.py
+++ b/aios3/bucket.py
@@ -242,7 +242,7 @@ class MultipartUpload(object):
         try:
             if result.status != 200:
                 xml = yield from result.read()
-                raise errors.AWSException.from_bytes(result.status, xml)
+                raise errors.AWSException.from_bytes(result.status, xml, self.key + ":" +str(partNumber))
             if not isCopy:
                 etag = result.headers['ETAG']
             else:
@@ -278,7 +278,7 @@ class MultipartUpload(object):
         try:
             xml = yield from result.read()
             if result.status != 200:
-                raise errors.AWSException.from_bytes(result.status, xml)
+                raise errors.AWSException.from_bytes(result.status, xml, self.key)
             xml = parse_xml(xml)
             return xml.find('s3:ETag', namespaces=NS)
         finally:
@@ -296,7 +296,7 @@ class MultipartUpload(object):
         try:
             xml = yield from result.read()
             if result.status != 204:
-                raise errors.AWSException.from_bytes(result.status, xml)
+                raise errors.AWSException.from_bytes(result.status, xml, self.key)
         finally:
             yield from result.wait_for_close()
 
@@ -338,7 +338,7 @@ class Bucket(object):
             ))
         data = (yield from result.read())
         if result.status != 200:
-            raise errors.AWSException.from_bytes(result.status, data)
+            raise errors.AWSException.from_bytes(result.status, data, self._name)
         x = parse_xml(data)
         return any(map(Key.from_xml,
                         x.findall('s3:Contents', namespaces=NS)))
@@ -355,7 +355,7 @@ class Bucket(object):
             ))
         data = (yield from result.read())
         if result.status != 200:
-            raise errors.AWSException.from_bytes(result.status, data)
+            raise errors.AWSException.from_bytes(result.status, data, self._name)
         x = parse_xml(data)
         if x.find('s3:IsTruncated', namespaces=NS).text != 'false':
             raise AssertionError(
@@ -381,7 +381,7 @@ class Bucket(object):
                 ))
             data = (yield from result.read())
             if result.status != 200:
-                raise errors.AWSException.from_bytes(result.status, data)
+                raise errors.AWSException.from_bytes(result.status, data, self._name)
             x = parse_xml(data)
             result = list(map(Key.from_xml,
                             x.findall('s3:Contents', namespaces=NS)))
@@ -403,7 +403,7 @@ class Bucket(object):
             "HEAD", '/' + key, {}, {'HOST': self._host}, b''))
         if result.status != 200:
             raise errors.AWSException.from_bytes(
-                result.status, (yield from result.read()))
+                result.status, (yield from result.read()), key)
         return result
 
     @asyncio.coroutine
@@ -414,7 +414,7 @@ class Bucket(object):
             "GET", '/' + key, {}, {'HOST': self._host}, b''))
         if result.status != 200:
             raise errors.AWSException.from_bytes(
-                result.status, (yield from result.read()))
+                result.status, (yield from result.read()), key)
         return result
 
     @asyncio.coroutine
@@ -446,7 +446,7 @@ class Bucket(object):
         try:
             if result.status != 200:
                 xml = yield from result.read()
-                raise errors.AWSException.from_bytes(result.status, xml)
+                raise errors.AWSException.from_bytes(result.status, xml, key)
             return result
         finally:
             yield from result.wait_for_close()
@@ -473,7 +473,7 @@ class Bucket(object):
             "GET", '/' + key, {}, {'HOST': self._host}, b''))
         if result.status != 200:
             raise errors.AWSException.from_bytes(
-                result.status, (yield from result.read()))
+                result.status, (yield from result.read()), key)
         data = yield from result.read()
         return data
 
@@ -503,7 +503,7 @@ class Bucket(object):
         try:
             if result.status != 200:
                 xml = yield from result.read()
-                raise errors.AWSException.from_bytes(result.status, xml)
+                raise errors.AWSException.from_bytes(result.status, xml, key)
             xml = yield from result.read()
             upload_id = parse_xml(xml).find('s3:UploadId',
                                             namespaces=NS).text

--- a/aios3/bucket.py
+++ b/aios3/bucket.py
@@ -67,8 +67,14 @@ class Request(object):
 
     @property
     def url(self):
-        return 'http://{0.headers[HOST]}{0.resource}?{0.query_string}' \
-            .format(self)
+        hostHeader = self.headers['HOST']
+        hostPort = hostHeader.split(':')
+        proto = 'http'
+        if (len(hostPort) == 2):
+            if (hostPort[1] == '443'):
+                proto = 'https'
+        return '{1}://{0.headers[HOST]}{0.resource}?{0.query_string}' \
+            .format(self, proto)
 
 
 def _hmac(key, val):

--- a/aios3/bucket.py
+++ b/aios3/bucket.py
@@ -228,7 +228,7 @@ class MultipartUpload(object):
         if (isinstance(data, ObjectChunk)):
             objChunk = data
             data = b''
-            srcPath = "/{0}/{1}".format(objChunk.bucket, objChunk.key)
+            srcPath = "/{0}/{1}".format(objChunk.bucket, amz_uriencode(objChunk.key))
             if (objChunk.versionId is not None):
                 srcPath = srcPath + "?versionId={0}".format(objChunk.versionId)
             headers['x-amz-copy-source'] = srcPath

--- a/aios3/errors.py
+++ b/aios3/errors.py
@@ -5,7 +5,7 @@ class AWSException(Exception):
     """Base for exceptions returned by amazon"""
 
     @staticmethod
-    def from_bytes(status, body):
+    def from_bytes(status, body, url=None):
         if not body:
             # sometimes Riak CS doesn't have response body :(
             # TODO(tailhook) maybe use status to create specific error?
@@ -26,7 +26,10 @@ class AWSException(Exception):
         except KeyError:
             raise RuntimeError("Error {} is unknown".format(class_name))
         msg = xml.find("Message")
-        return cls(class_name if msg is None else msg.text)
+        msg = class_name if msg is None else msg.text
+        if (url is not None):
+            msg = url + " " + msg
+        return cls(msg)
 
 
 class NotFound(Exception): pass

--- a/aios3/errors.py
+++ b/aios3/errors.py
@@ -29,6 +29,7 @@ class AWSException(Exception):
 class AccessDenied(AWSException): pass
 class AccountProblem(AWSException): pass
 class AmbiguousGrantByEmailAddress(AWSException): pass
+class AuthorizationHeaderMalformed(AWSException): pass
 class BadDigest(AWSException): pass
 class BucketAlreadyExists(AWSException): pass
 class BucketAlreadyOwnedByYou(AWSException): pass

--- a/aios3/errors.py
+++ b/aios3/errors.py
@@ -9,7 +9,10 @@ class AWSException(Exception):
         if not body:
             # sometimes Riak CS doesn't have response body :(
             # TODO(tailhook) maybe use status to create specific error?
-            raise RuntimeError("HTTP Error {}".format(status))
+            if (status != 404):
+                raise RuntimeError("HTTP Error {}".format(status))
+            else:
+                raise NotFound()
         try:
             xml = parse_xml(body)
         except ParseError:
@@ -25,6 +28,8 @@ class AWSException(Exception):
         msg = xml.find("Message")
         return cls(class_name if msg is None else msg.text)
 
+
+class NotFound(Exception): pass
 
 class AccessDenied(AWSException): pass
 class AccountProblem(AWSException): pass

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
     from distutils.core import setup
 
 setup(name='aio-s3',
-      version='0.2',
+      version='0.3',
       description='Asyncio-based client for S3',
       author='Paul Colomiets',
       author_email='paul@colomiets.name',

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 setup(name='aio-s3',
-      version='0.1',
+      version='0.2',
       description='Asyncio-based client for S3',
       author='Paul Colomiets',
       author_email='paul@colomiets.name',
@@ -11,7 +14,7 @@ setup(name='aio-s3',
       packages=[
           'aios3',
       ],
-      requires=['aiohttp'],
+      requires=['aiohttp', 'xmltodict'],
       classifiers=[
           'Development Status :: 4 - Beta',
           'Programming Language :: Python :: 3',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
     from distutils.core import setup
 
 setup(name='aio-s3',
-      version='0.3',
+      version='0.4.0',
       description='Asyncio-based client for S3',
       author='Paul Colomiets',
       author_email='paul@colomiets.name',


### PR DESCRIPTION
- switches to use botocore’s auth module so we’re not
  replicating/maintaining signing methods
- switches to path style API calls to support buckets with names
- gets rid of port parameter since s3 does not listen on ports besides
  80/443.
